### PR TITLE
Add Cash Flow Statement report

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ def main():
     processor = DataProcessor()
     pl_statement = processor.generate_profit_loss_statement(invoices, bills)
     balance_data = processor.generate_balance_sheet_data(accounts)
+    cf_statement = processor.generate_cash_flow_statement(pl_statement, accounts)
 
     output_format = args.format
     current_date = datetime.now().strftime("%Y_%m_%d")
@@ -198,6 +199,8 @@ def main():
                                   start_date=start_date, end_date=end_date)
     report_gen.export_balance_sheet(balance_data, file_name=f"Balance_Sheet_{current_date}",
                                     report_date=end_date)
+    report_gen.export_cash_flow(cf_statement, file_name=f"Cash_Flow_{current_date}",
+                                start_date=start_date, end_date=end_date)
 
     print("[INFO] Financial reporting completed successfully.")
 


### PR DESCRIPTION
## Summary
- Adds the third core financial statement (Cash Flow) using the indirect method
- `data_processor.py`: new `generate_cash_flow_statement()` builds operating, investing, and financing sections from P&L net income and account balances
- `reporting.py`: new `export_cash_flow()` with the same Excel/CSV formatting as P&L and Balance Sheet
- `main.py`: generates Cash Flow automatically alongside the other two reports
- 12 new tests covering all three sections, edge cases, and both export formats (46 total now)

## Test plan
- [ ] CI passes
- [ ] `pytest tests/ -v` — all 46 tests pass
- [ ] Cash Flow Excel output has correct title, sections, and formatting
- [ ] Cash Flow CSV output includes all line items

Closes #14